### PR TITLE
feat: 홈 화면에 최신 상품 8개 카드로 출력되도록 API 연동 및 클릭 시 상세 페이지 이동 구현

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -1,10 +1,10 @@
 /*
 파일명  : Navbar.css
 파일설명 : LocalEat 네비게이션 바에 대한 스타일 정의
-          - 반응형 레이아웃 고려 (Flex 기반 정렬)
+          - 반응형 레이아웃 고려 (Flex 기반 정렬로.)
           - 로고, 메뉴, 검색창, 아이콘 등 각 요소별 스타일링 포함
 작성자  : 정여진
-작성일  : 2025-04-09.~
+작성일  : 2025-04-09.~2025.04.14.
 */
 .navbar {
     position: fixed;
@@ -48,6 +48,9 @@
     height: 50px;
     background-color: rgba(3, 199, 90, 0.1);
     border-radius: 15px;
+    display: flex;
+    align-items: center;
+    padding: 0 15px;
 }
 
 .menu {
@@ -96,11 +99,11 @@
 }
 .search-input {
     flex: 1;
-    border: none;
+    border: none !important;
     background: transparent;
     outline: none;
     font-size: 16px;
     padding-left: 10px;
     position: relative;
-    top: -2.5px;
+    height: 100%;
 }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -4,7 +4,7 @@
           - 로고, 검색창, 메뉴 항목, 아이콘 렌더링
           - 전체 페이지에서 고정(top fixed)되어 사용
 작성자  : 정여진
-작성일  : 2025-04-09.~
+작성일  : 2025-04-09.~2025.04.14.
 */
 import React, { useState } from 'react';
 import './Navbar.css';

--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -5,10 +5,19 @@
 기간 : 2025-04-10.
 */
 import './ProductCard.css';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
-const ProductCard = ({ image, tags, title, originalPrice, discountPrice }) => {
+
+const ProductCard = ({ id, image, tags, title, originalPrice, discountPrice}) => {
+    const navigate = useNavigate();
+
+    const handleClick = () => {
+        navigate(`/products/${id}`);
+    };
+
     return (
-        <div className="product-card">
+        <div className="product-card" onClick={handleClick} style={{ cursor: 'pointer' }}>
             <img className="product-img" src={image} alt={title} />
 
             <div className="tag-list">

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -2,10 +2,10 @@
 파일명 : Home.jsx
 파일설명 : 로컬잇 웹사이트의 메인(홈) 화면 UI
 작성자 : 정여진
-기간 : 2025-04-09.~
+기간 : 2025-04-09.~2025.04.14.
 */
 
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import './Home.css';
 import TagBadge from '../../components/Tag/TagBadge';
 import {getTagsByType} from '../../components/Tag/tags';
@@ -15,78 +15,36 @@ import ProductCard from "../../components/ProductCard/ProductCard";
 import FloatingButton from "./FloatingButton"; // 임시 이미지
 import {useNavigate} from "react-router-dom";
 import {ROUTES} from "../../components/routes";
-
-/* 임시로. 나중에 데이터에서 가져올 것. */
-const products = [
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    {
-        image: carrotImg,
-        title: '국내산 세척당근',
-        originalPrice: 2000,
-        discountPrice: 1300,
-        tags: ['강원', 'GOOD'],
-    },
-    // ... 총 8개 만들어줘야 함
-];
+import axios from 'axios';
 
 const Home = () => {
 
     const navigate = useNavigate();
+    const [products, setProducts] = useState([]);
+    const regionTags = getTagsByType('region');
+
+    useEffect(() => {
+        axios.get('/api/products/latest')
+            .then(res => {
+                console.log('홈 화면 데이터: ', res.data);
+                const data = res.data.map(p => ({
+                    id: p.id, // 여기서 id 값 넘겨야 합니다.
+                    image: `/api/images/by-product/${p.id}`, // 여기만 따로
+                    title: p.productName,
+                    originalPrice: p.price,
+                    discountPrice: Math.floor(p.price * (1 - (p.gradeDiscountRate ?? 0))),
+                    tags: p.tags ?? [],
+                }));
+                setProducts(data);
+            })
+            .catch(err => console.error('최신 상품 불러오기 실패', err));
+    }, []);
 
     const handleTagClick = () => {
         navigate(ROUTES.SEARCH);
         window.scrollTo(0,0);
     }
 
-    const regionTags = getTagsByType('region');
     return (
         <div className="banner-container">
             <img
@@ -94,6 +52,7 @@ const Home = () => {
                 src={bannerImage}
                 alt="배너"
             />
+
 
             {/*알뜰상품 바로가기 버튼*/}
             <FloatingButton onClick={handleTagClick}/>


### PR DESCRIPTION
- /api/products/latest 호출하여 상품 리스트 출력
- productId 기반 이미지 경로(`/api/images/by-product/{productId}`) 구성
- ProductCard 클릭 시 `/products/{id}`로 이동 처리 추가
- 검색창 스타일 수정 (테두리 제거, 정렬 개선)