### PR TITLE
fix: 상품 목록에서 price null 처리 및 등록일 칸 UI 개선

### DIFF
--- a/src/pages/MypageSeller/ProductList.css
+++ b/src/pages/MypageSeller/ProductList.css
@@ -46,7 +46,7 @@
 .sidebar ul {
     list-style: none;
     padding: 0;
-    margin: 10;
+    margin: 10px;
 }
 
 .sidebar li {
@@ -125,6 +125,8 @@ table {
 
 th,
 td {
+    text-align:center;
+    vertical-align: middle;
     padding: 0.75rem;
     border-bottom: 1px solid #ddd;
     word-break: keep-all;
@@ -132,4 +134,9 @@ td {
 
 thead {
     background-color: #f0f0f0;
+}
+
+/* 등록일(날짜) 칸만 넓히기 */
+td:nth-child(6), th:nth-child(6) {
+    min-width: 130px;
 }

--- a/src/pages/MypageSeller/ProductList.jsx
+++ b/src/pages/MypageSeller/ProductList.jsx
@@ -114,8 +114,10 @@ function ProductList() {
                                     <td>{item.isGroupBuy  ? 'O' : 'X'}</td>
                                     <td>{item.productGrade}</td>
                                     <td>{localTypeToLabel[item.local] || item.local}</td>
-                                    <td>{item.price.toLocaleString()}원</td>
-                                    <td>{new Date(item.createAt).toLocaleDateString()}</td>
+                                    <td>{item.price != null ? item.price.toLocaleString() + '원' : '가격 미정'}</td>
+                                    <td>
+                                        {item.createAt ? new Date(item.createAt).toLocaleDateString() : '등록일 없음'}
+                                    </td>
                                     <td><button className="modify-btn" onClick={() => handleEdit(item)}>수정</button></td>
                                     <td><button className="delete-btn" onClick={() => openDeletePopup(item.id)}>삭제</button></td>
                                 </tr>

--- a/src/pages/MypageSeller/ProductRegister.jsx
+++ b/src/pages/MypageSeller/ProductRegister.jsx
@@ -116,7 +116,7 @@ const ProductRegister = () => {
 
         const payload = {
             productName: formData.name,
-            price: formData.price ? Number(formData.price) : null,
+            price: !isNaN(Number(formData.price)) ? Number(formData.price) : 0,
             local: formData.region || null,
             isGroupBuy: formData.groupbuy === 'O' ? true : formData.groupbuy === 'X' ? false : null,
             productGrade: formData.cheap === 'O' ? 'B' : formData.cheap === 'X' ? 'A' : null,


### PR DESCRIPTION
- 상품 가격이 null일 경우 "가격 미정"으로 안전하게 출력
- 등록일(createAt)이 null일 경우 "등록일 없음"으로 처리
- 모든 테이블 셀 가운데 정렬
- 등록일 열(min-width: 130px) 설정으로 날짜가 잘리던 현상 해결