### PR TITLE
💄Style/group buy UI#20

### DIFF
--- a/src/components/Tag/tags.js
+++ b/src/components/Tag/tags.js
@@ -11,7 +11,7 @@ const tags = [
     { type: 'region', label: '서울/경기/인천', code: 'SGI', bg: 'rgba(171, 78, 82, 0.1)', color: '#AB4E52' },
     { type: 'region', label: '강원', code: 'GANGWON', bg: 'rgba(244, 166, 136, 0.1)', color: '#F4A688' },
     { type: 'region', label: '충청', code: 'CHUNGCHEONG', bg: 'rgba(110, 75, 53, 0.1)', color: '#6E4B35' },
-    { type: 'region', label: '전북',code: 'CHUNGCHEONG', bg: 'rgba(164, 215, 146, 0.1)', color: '#A4D792' },
+    { type: 'region', label: '전북',code: 'JEONBUK', bg: 'rgba(164, 215, 146, 0.1)', color: '#A4D792' },
     { type: 'region', label: '전남/광주',code: 'JNGJ', bg: 'rgba(0, 178, 169, 0.1)', color: '#00B2A9' },
     { type: 'region', label: '대구/경북',code: 'DGGB', bg: 'rgba(116, 139, 171, 0.1)', color: '#748BAB' },
     { type: 'region', label: '경남/부산/울산', code: 'GNBNUL',bg: 'rgba(208, 176, 132, 0.1)', color: '#D0B084' },

--- a/src/pages/GroupBuy/CreateGroupBuy.css
+++ b/src/pages/GroupBuy/CreateGroupBuy.css
@@ -105,14 +105,14 @@ display: inline-block;
 
 /* 클릭 시 효과 */
 .cgb-tag-item.selected {
-background-color: rgba(0, 0, 0, 0.65) !important;
-font-weight: bold;
+    font-weight: bold;
 }
 
 /* TagBadge 내부의 .tag가 있다면, 해당 요소에 스타일을 적용하는 방법 */
-.cgb-tag-item.selected .tag {
-background-color: rgba(0, 0, 0, 0.65) !important;
-font-weight: bold;
+.cgb-tag-item.selected .tag-badge {
+    font-weight: bold;
+    font-family: 'Pretendard', sans-serif;
+    letter-spacing: -0.5px;
 }
 
 .cgb-quantity-selector {
@@ -156,8 +156,7 @@ font-family: 'Pretendard', sans-serif;
 background: #f5f5f5;
 }
 
-.cgb-input-box,
-.cgb-input-box[readonly] {
+.cgb-section > .cgb-input-box {
   width: 530px;
   height: 66px;
   flex-shrink: 0;
@@ -168,9 +167,20 @@ background: #f5f5f5;
   padding-left: 20px;
   color: #000;
   background-color: #ffffff;
+  font-size: 18px;
+  font-family: 'Pretendard', sans-serif;
+  box-sizing: border-box;
+}
+
+.cgb-section > input[type="date"].cgb-input-box {
+  height: 66px;
 }
 
 .cgb-button-wrapper {
 text-align: right;
 margin-top: 30px;
+}
+
+.highlighted-tag {
+  font-weight: bold;
 }

--- a/src/pages/GroupBuy/CreateGroupBuy.jsx
+++ b/src/pages/GroupBuy/CreateGroupBuy.jsx
@@ -12,25 +12,49 @@ import './CreateGroupBuy.css'
 import TagBadge from '../../components/Tag/TagBadge';
 import { getTagsByType } from '../../components/Tag/tags'
 
-const RegionTags = ({ tags }) => {
+// 영어 지역명과 한글 태그명 매핑
+const localMap = {
+    'SGI': '서울/경기/인천',
+    'GANGWON': '강원',
+    'CHUNGCHEONG': '충청',
+    'JEONBUK': '전북',
+    'JNGJ': '전남/광주',
+    'DGGB': '대구/경북',
+    'GNBNUL': '경남/부산/울산',
+    'JEJU': '제주'
+};
+
+const RegionTags = ({ tags, local }) => {
     const [selectedIndex, setSelectedIndex] = useState(null);
+    // local 값을 한글로 변환
+    const localKorean = localMap[local] || local;
 
     const handleClick = (index) => {
         setSelectedIndex(index === selectedIndex ? null : index);
     };
 
+    const normalize = str => (str || '').trim().replace(/／/g, '/');
+
     return (
         <div className="cgb-region-tags-wrapper">
             <div className="cgb-region-tags">
-                {tags.map((tag, index) => (
-                    <div key={index} onClick={() => handleClick(index)}>
-                        <TagBadge
-                            label={tag.label}
-                            bg={tag.bg}
-                            color={tag.color}
-                        />
-                    </div>
-                ))}
+                {tags.map((tag, index) => {
+                    const isLocalTag = normalize(tag.label) === normalize(localKorean);
+                    return (
+                        <div
+                            key={index}
+                            onClick={() => handleClick(index)}
+                            className={`cgb-tag-item${isLocalTag ? ' selected' : ''}`}
+                        >
+                            <TagBadge
+                                label={tag.label}
+                                bg={isLocalTag ? tag.bg.replace(/0\.[0-9]+\)/, '1)') : tag.bg}
+                                color={isLocalTag ? '#000' : tag.color}
+                                style={isLocalTag ? { fontWeight: 'bold' } : {}}
+                            />
+                        </div>
+                    );
+                })}
             </div>
         </div>
     );
@@ -57,7 +81,8 @@ const CreateGroupBuy = () => {
                 productId: productId,
                 description: description,
                 quantity: quantity,
-                deadline: deadline
+                deadline: deadline,
+                local: local
             }, {
                 headers: {
                     "X-USER-ID": userId
@@ -91,7 +116,7 @@ const CreateGroupBuy = () => {
                 <div className="cgb-left-section">
                     <div className="cgb-section">
                         <p className="cgb-section-title">지역 선택</p>
-                        <RegionTags tags={regionTags} />
+                        <RegionTags tags={regionTags} local={local} />
                     </div>
                     <div className="cgb-section">
                         <p className="cgb-section-title">구매할 수량 선택</p>

--- a/src/pages/GroupBuy/GroupBuyDetail.css
+++ b/src/pages/GroupBuy/GroupBuyDetail.css
@@ -30,16 +30,19 @@
     font-weight: 500;
     font-style: normal;
     text-align: center;
-    margin-bottom: 34px;
+    margin-bottom: 15px;
     color: #000;
 }
 
 .dgb-time-guide {
     font-family: Pretendard;
-    font-size: 26px;
-    font-style: normal;
+    font-size: 30px;
+    font-weight: 300;
+    border-radius: 6px;
+    padding: 16px 0;
     text-align: center;
-    margin-bottom: 34px;
+    margin: 0 auto 20px auto;
+    width: 480px;
     color: #000;
 }
 
@@ -78,7 +81,7 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    gap: 15px;
+    gap: 10px;
 }
 
 .dgb-top-row {
@@ -97,12 +100,13 @@
 }
 
 .dgb-groupBuy-guide {
-    font-size: 26px;
+    font-size: 24px;
     color: #000;
     font-family: 'Pretendard', sans-serif;
     font-style: normal;
     font-weight: 500;
     line-height: normal;
+    margin: 0;
 }
 
 .dgb-divider {
@@ -151,4 +155,27 @@
     color: #000;
     padding: 5px 10px;
     cursor: pointer;
+}
+
+.dgb-participants {
+    font-size: 20px;
+    font-weight: 400;
+    /* background: #c6edfd; */
+    border-radius: 6px;
+    padding: 10px 0 10px 16px;
+    text-align: left;
+    width: 100%;
+    margin: 0 0 18px 0;
+    color: #000;
+    box-sizing: border-box;
+}
+
+.dgb-participants-label {
+    font-weight: 700;
+    font-size: 28px;
+}
+.dgb-participants-count {
+    font-weight: 400;
+    font-size: 20px;
+    margin-left: 4px;
 }

--- a/src/pages/GroupBuy/GroupBuyDetail.jsx
+++ b/src/pages/GroupBuy/GroupBuyDetail.jsx
@@ -1,13 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import axios from 'axios';
-import './GroupBuyDetail.css'
+import './GroupBuyDetail.css';
 
 const GroupBuyDetail = () => {
-    const navigate = useNavigate();
     const location = useLocation();
-
-    // 이전 페이지에서 넘겨준 값들
     const {
         groupBuyId,
         productId,
@@ -45,40 +42,26 @@ const GroupBuyDetail = () => {
     return (
         <div className="dgb-container">
             <p className="dgb-title">공동 구매 상세 정보</p>
-            <p className="dgb-sub">
-                내가 참여한 공동 구매의 정보, 마감 시간 등을 확인해 보세요
-            </p>
-            <p className="dgb-time-guide">
-                공동구매 성사까지 남은 시간 {detail.remainingTime}
-            </p>
-
+            <p className="dgb-sub">내가 참여한 공동 구매의 정보, 마감 시간 등을 확인해 보세요</p>
+            <p className="dgb-time-guide">공동구매 성사까지 남은 시간 <span style={{color:'#03C75A', fontWeight:'bold'}}>{detail.remainingTime}</span></p>
             <div className="dgb-groupBuy-box">
                 <div className="dgb-header-section">
                     <div className="dgb-img-wrapper">
-                        <img
-                            className="qproduct-image"
-                            src={imageUrl || detail.imageUrl || '/placeholder.png'}
-                            alt={productName || detail.productName}
-                        />
+                        <img className="dgb-product-image" src={imageUrl || detail.imageUrl || '/placeholder.png'} alt={productName || detail.productName} />
                     </div>
                     <div className="dgb-product-info">
                         <div className="dgb-top-row">
                             <p className="dgb-product-name">{detail.productName}</p>
                         </div>
-                        <p className="dgb-groupBuy-description">
-                            {detail.description}
-                        </p>
+                        <p className="dgb-groupBuy-guide">{detail.description}</p>
                     </div>
                 </div>
-
                 <hr className="dgb-divider" />
-
                 <div className="dgb-list-wrapper">
-                    <p className="dgb-participants">참여인원</p>
-                    <p className="dgb-count">
-                        ( {detail.partiCount} / {detail.maxParticipants} )
+                    <p className="dgb-participants">
+                        <span className="dgb-participants-label">참여 인원</span>
+                        <span className="dgb-participants-count">( {detail.partiCount} / {detail.maxParticipants} )</span>
                     </p>
-
                     {detail.participants.map((p) => (
                         <div key={p.consumerId} className="dgb-list">
                             <p className="dgb-list-text">
@@ -88,10 +71,6 @@ const GroupBuyDetail = () => {
                     ))}
                 </div>
             </div>
-
-            <button className="dgb-back-button" onClick={() => navigate(-1)}>
-                뒤로가기
-            </button>
         </div>
     );
 };

--- a/src/pages/GroupBuy/JoinGroupBuy.css
+++ b/src/pages/GroupBuy/JoinGroupBuy.css
@@ -120,6 +120,10 @@ background-color: rgba(0, 0, 0, 0.65) !important;
 font-weight: bold;
 }
 
+.jgb-tag-item.selected .tag-badge {
+    font-weight: bold !important;
+}
+
 .jgb-quantity-selector {
 display: flex;
 align-items: center;

--- a/src/pages/GroupBuy/JoinGroupBuy.jsx
+++ b/src/pages/GroupBuy/JoinGroupBuy.jsx
@@ -13,25 +13,41 @@ import { getTagsByType } from '../../components/Tag/tags';
 import axios from 'axios';
 import { useLocation } from 'react-router-dom';
 
-const RegionTags = ({ tags }) => {
-    const [selectedIndex, setSelectedIndex] = useState(null);
+// 영어 지역명과 한글 태그명 매핑
+const localMap = {
+    'SGI': '서울/경기/인천',
+    'GANGWON': '강원',
+    'CHUNGCHEONG': '충청',
+    'JEONBUK': '전북',
+    'JNGJ': '전남/광주',
+    'DGGB': '대구/경북',
+    'GNBNUL': '경남/부산/울산',
+    'JEJU': '제주'
+};
 
+const RegionTags = ({ tags, local }) => {
+    const [selectedIndex, setSelectedIndex] = useState(null);
+    const localKorean = localMap[local] || local;
+    const normalize = str => (str || '').trim().replace(/／/g, '/');
     const handleClick = (index) => {
         setSelectedIndex(index === selectedIndex ? null : index);
     };
-
     return (
         <div className="jgb-region-tags-wrapper">
             <div className="jgb-region-tags">
-                {tags.map((tag, index) => (
-                    <div key={index} onClick={() => handleClick(index)}>
-                        <TagBadge
-                            label={tag.label}
-                            bg={tag.bg}
-                            color={tag.color}
-                        />
-                    </div>
-                ))}
+                {tags.map((tag, index) => {
+                    const isLocalTag = normalize(tag.label) === normalize(localKorean);
+                    return (
+                        <div key={index} onClick={() => handleClick(index)}>
+                            <TagBadge
+                                label={tag.label}
+                                bg={isLocalTag ? tag.bg.replace(/0\.[0-9]+\)/, '1)') : tag.bg}
+                                color={isLocalTag ? '#000' : tag.color}
+                                style={isLocalTag ? { fontWeight: 'bold' } : {}}
+                            />
+                        </div>
+                    );
+                })}
             </div>
         </div>
     );
@@ -95,7 +111,7 @@ const JoinGroupBuy = () => {
                 <div className="jgb-left-section">
                     <div className="jgb-section">
                         <p className="jgb-section-title">지역 선택</p>
-                        <RegionTags tags={regionTags} />
+                        <RegionTags tags={regionTags} local={local} />
                     </div>
 
                     <div className="jgb-section">


### PR DESCRIPTION
## 📌연관된 이슈 번호
#20 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
공동구매 참여하기, 만들기 페이지에서 지역 태그 활성화 작업,
공동구매 상세 조회의 UI 수정 완료했습니다.

## 💬리뷰 포인트 (선택)
공동구매 지역 태그들이 색이 너무 옅어서 최대한 차이를 줘 보려고 배경 투명도 1로 진행하고,
글씨도 검게 바꿨는데 이렇게 하면 서울/경기/인천이 너무 진해지더라구요...
그래도 다들 괜찮으신가요? 소망님 컨펌 한 번 받긴 했는데 제가 공동 Tag 컴포넌트를 수정할 수 없어서 최대한 제 코드 안에서 고쳐보았어요.

## 테스트 결과 (선택)
![image](https://github.com/user-attachments/assets/3540e8a0-dd04-4c66-af52-d1db0e43b2da)
공동구매 만들기 지역 태그 서울/인천/경기 색
![image](https://github.com/user-attachments/assets/921b5299-0852-431e-99fc-6bbc6692274d)
공동구매 참여하기 지역 태그 전북 색
![image](https://github.com/user-attachments/assets/20e79d8e-3dc4-4493-8063-849c58167924)
![image](https://github.com/user-attachments/assets/4aa26046-3deb-4499-b7c0-069b9d27cb71)
![image](https://github.com/user-attachments/assets/93671b3a-6d39-4b36-a1c4-7d91b9acf0bc)
순서대로 전북, 제주, 강원 색
![image](https://github.com/user-attachments/assets/aff4b889-32ac-44af-a1c7-74cb28762c72)
공동구매 상세 조회 페이지 UI 수정 (이제 상품 사진 크기 깨지는 일 없을 것 같습니다!)
