### PR TITLE
🔧Fix: Update 공동구매 장바구니 가격 표시 수정

### DIFF
--- a/src/pages/cart/CartGroupBuy.jsx
+++ b/src/pages/cart/CartGroupBuy.jsx
@@ -46,7 +46,7 @@ const CartGroupBuy = () => {
                             groupBuyId: item.groupBuyId,
                             productId: item.productId,
                             name: product.productName,
-                            price: product.price,
+                            price: Math.floor(product.price * 0.9), // 10% 할인된 가격
                             quantity: item.quantity,
                             paymentStatus: item.paymentStatus,
                             addedAt: new Date(item.addedAt),
@@ -201,7 +201,12 @@ const CartGroupBuy = () => {
                                 />
                             </td>
                             <td>{item.name}</td>
-                            <td>{item.price?.toLocaleString() ?? '0'}원</td>
+                            <td>
+                                <span style={{ textDecoration: 'line-through', color: 'gray', marginRight: '8px' }}>
+                                    {item.price / 0.9?.toLocaleString() ?? '0'}원
+                                </span>
+                                {item.price?.toLocaleString() ?? '0'}원
+                            </td>
                             <td>{item.quantity}</td>
                             <td>{(item.price * item.quantity)?.toLocaleString() ?? '0'}원</td>
                             <td style={expired[item.id] ? { color: 'gray' } : {}}>


### PR DESCRIPTION
## 📌연관된 이슈 번호
#75 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
공동구매 장바구니에서 할인된 가격으로 출력되게 수정했습니다.

## 💬리뷰 포인트 (선택)
지금은 회색 글씨로 원가 뜨고 할인된 가격이 검은 글씨로 뜨는데,
굳이 싶으시면 할인된 가격만 뜨게 수정할게요!

## 테스트 결과 (선택)
![image](https://github.com/user-attachments/assets/6b52be36-1588-4e68-b559-372368c65b8c)
공동구매 장바구니 화면에서 할인된 가격 출력

![image](https://github.com/user-attachments/assets/f2aa3b54-b764-4caa-b905-929ac48f488d)
주문 내역 화면에서 할인된 가격으로 변경되어 출력
