### PR TITLE
feat: 구독 장바구니 및 구독 주문 기능 프론트 연동

### DIFF
--- a/src/components/ProductCard/ProductCard.css
+++ b/src/components/ProductCard/ProductCard.css
@@ -16,8 +16,8 @@
 }
 
 .product-img {
-    width: 100%;
-    height: 187px;
+    width: 280px;
+    height: 180px;
     object-fit: cover;
 }
 

--- a/src/components/ProductCard/ProductCard.jsx
+++ b/src/components/ProductCard/ProductCard.jsx
@@ -21,6 +21,7 @@ const ProductCard = ({ id, image, tags = [], title, originalPrice, discountPrice
     return (
         <div className="product-card" onClick={handleClick} style={{ cursor: 'pointer' }}>
             <img
+                className="product-img"
                 src={image}
                 alt={title}
                 onError={(e) => { e.target.src = carrotImg; }}

--- a/src/components/api/cart-subscribe.js
+++ b/src/components/api/cart-subscribe.js
@@ -27,7 +27,7 @@ export const addToSubscribeCart = async ({
         ? JSON.parse(localStorage.getItem('user')).userId
         : undefined;
 
-    const response = await api.post('/api/general-cart/items', {
+    const response = await api.post('/api/cart/subscribe/items', {
         productId,
         quantity,
         price,

--- a/src/components/api/subscribe.js
+++ b/src/components/api/subscribe.js
@@ -6,10 +6,6 @@
  * */
 import api from './axios';  // 공통 axios 인스턴스
 
-
-const storedUser = localStorage.getItem('user');
-const userId = storedUser ? JSON.parse(storedUser)?.userId : null;
-
 /**
  * 구독 주문 생성 요청
  * @param {Object} params - 구독 주문 정보
@@ -19,8 +15,6 @@ const userId = storedUser ? JSON.parse(storedUser)?.userId : null;
  * @param {number} params.deliveryPeriodInMonths - 구독 총 기간 (단위: 개월)
  * @returns {Promise<Object>} 서버 응답 데이터
  */
-
-
 export const createSubscribeOrder = async ({ productId, quantity, deliveryCycle, deliveryPeriodInMonths }) => {
     const storedUser = localStorage.getItem("user");
     const parsedUser = storedUser ? JSON.parse(storedUser) : null;
@@ -35,6 +29,7 @@ export const createSubscribeOrder = async ({ productId, quantity, deliveryCycle,
         deliveryPeriodInMonths
     };
 
+    // POST 요청 + userId는 Header에 포함
     const response = await api.post('/api/subscribe-order', payload, {
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/MypageBuyer/WishlistManage.css
+++ b/src/pages/MypageBuyer/WishlistManage.css
@@ -93,7 +93,7 @@ thead {
     color: white;
     border: none;
     padding: 6px 14px;
-    margin-left:92%;
+    margin-right: 8px;
     margin-bottom:6px;
     cursor: pointer;
     border-radius: 4px;

--- a/src/pages/productDetail/ProductDetail.jsx
+++ b/src/pages/productDetail/ProductDetail.jsx
@@ -183,7 +183,8 @@ const ProductDetail = () => {
                 productId: product.id,
                 quantity,
                 price: subscribePrice,
-                deliveryCycle,
+                cycleType: deliveryCycle.cycleType,
+                cycleValue: deliveryCycle.cycleValue,
                 deliveryPeriodInMonths
             });
 


### PR DESCRIPTION
## 📌연관된 이슈 번호
ex) #1

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ]  구독 (장바구니)

## 📝작업 내용
- ProductDetail.jsx에서 구독 상품 장바구니 담기(addToSubscribeCart) 연동
- createSubscribeOrder 함수로 구독 상품 즉시 구매 기능 구현
- quantity, deliveryCycle, deliveryPeriodInMonths 상태 관리 추가
- 구독 여부에 따라 일반/구독 가격 계산 및 주문 흐름 분기 처리
- 장바구니 추가/결제 완료 후 라우팅 및 팝업 처리 로직 개선

## 테스트 결과 (선택)
![image](https://github.com/user-attachments/assets/bb784558-8690-436f-ad41-3aa967d23dc2)

